### PR TITLE
fixed math for d3d12 quad sample

### DIFF
--- a/src/Direct3D12/03_DrawQuad/DrawQuadApp.cs
+++ b/src/Direct3D12/03_DrawQuad/DrawQuadApp.cs
@@ -90,7 +90,7 @@ internal class DrawQuadApp : D3D12Application
 
         // Vertex Buffer
         int stride = VertexPositionColor.SizeInBytes;
-        int vertexBufferSize = 3 * stride;
+        int vertexBufferSize = 4 * stride;
         CommandList.IASetVertexBuffers(0, new VertexBufferView(_vertexBuffer.GPUVirtualAddress, vertexBufferSize, stride));
 
         // Index Buffer


### PR DESCRIPTION
This sample was rendering a triangle not a quad. Now after my awesome full revamp of all the sample framework and fixes of approximately 782 bugs with a diff of +572.732 -438.325 this lasting nuisance has finally been fixed. :trollface: 